### PR TITLE
Updated to NLog 4.5 RTM to support NetCore

### DIFF
--- a/src/NServiceBus.NLog/NServiceBus.NLog.csproj
+++ b/src/NServiceBus.NLog/NServiceBus.NLog.csproj
@@ -1,19 +1,24 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(SolutionDir)NServiceBus.snk</AssemblyOriginatorKeyFile>
     <Description>NLog support for NServiceBus</Description>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="NLog" Version="[4.0.0, 5.0.0)" />
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
+    <PackageReference Include="NLog" Version="4.0.0" />
+    <PackageReference Include="NServiceBus" Version="6.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="NLog" Version="4.5.0" />
     <PackageReference Include="NServiceBus" Version="[7.0.0-beta0012, 8.0.0)" />
-    <PackageReference Include="Particular.Packaging" Version="0.1.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Particular.Packaging" Version="0.1.0" PrivateAssets="All" />
     <PackageReference Include="SourceLink.Create.GitHub" Version="2.5.0" PrivateAssets="All" />
     <DotNetCliToolReference Include="dotnet-sourcelink-git" Version="2.5.0" />
   </ItemGroup>


### PR DESCRIPTION
Update NLog-project so this line can be removed:

` Waiting for stable release of NLog 4.5.0, which introduces .NET Core support`

https://docs.particular.net/nservicebus/upgrades/supported-platforms